### PR TITLE
Make CSRF optional and customisable

### DIFF
--- a/lib/reduxRest.js
+++ b/lib/reduxRest.js
@@ -10,7 +10,7 @@ Object.defineProperty(exports, '__esModule', {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+var _get = function get(_x2, _x3, _x4) { var _again = true; _function: while (_again) { var object = _x2, property = _x3, receiver = _x4; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x2 = parent; _x3 = property; _x4 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
@@ -43,8 +43,22 @@ exports.asyncDispatch = asyncDispatch;
 
 var Endpoint = (function () {
   function Endpoint(url) {
+    var _ref = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+    var _ref$withCSRF = _ref.withCSRF;
+    var withCSRF = _ref$withCSRF === undefined ? false : _ref$withCSRF;
+    var _ref$CSRFHeaderName = _ref.CSRFHeaderName;
+    var CSRFHeaderName = _ref$CSRFHeaderName === undefined ? 'X-CSRFToken' : _ref$CSRFHeaderName;
+    var _ref$CSRFCookieName = _ref.CSRFCookieName;
+    var CSRFCookieName = _ref$CSRFCookieName === undefined ? 'csrftoken' : _ref$CSRFCookieName;
+    var setCSRF = _ref.setCSRF;
+
     _classCallCheck(this, Endpoint);
 
+    this.withCSRF = withCSRF;
+    this.CSRFHeaderName = CSRFHeaderName;
+    this.CSRFCookieName = CSRFCookieName;
+    this.setCSRF = setCSRF;
     this.url = url;
   }
 
@@ -80,10 +94,15 @@ var Endpoint = (function () {
   }, {
     key: '_setCSRFHeader',
     value: function _setCSRFHeader(request) {
-      // TODO this is django specific, needs to be customisable
+      if (this.setCSRF) {
+        return this.setCSRF(request);
+      }
+      if (!this.withCSRF) {
+        return request;
+      }
       if (!this._csrfSafeMethod(request.method)) {
         // && !this.crossDomain) {
-        request.set('X-CSRFToken', this._getCookie('csrftoken'));
+        request.set(this.CSRFHeaderName, this._getCookie(this.CSRFCookieName));
       }
       return request;
     }
@@ -351,7 +370,7 @@ var CollectionReducer = (function (_BaseReducer2) {
 
 exports.CollectionReducer = CollectionReducer;
 
-var Flux = function Flux(APIConf) {
+var Flux = function Flux(APIConf, CSRFOptions) {
   _classCallCheck(this, Flux);
 
   this.API = {};
@@ -361,7 +380,7 @@ var Flux = function Flux(APIConf) {
   for (var endpointName in APIConf) {
     if (APIConf.hasOwnProperty(endpointName)) {
       var url = APIConf[endpointName];
-      this.API[endpointName] = new Endpoint(url);
+      this.API[endpointName] = new Endpoint(url, CSRFOptions);
       this.actionTypes[endpointName] = new ActionTypes(endpointName);
       this.actionCreators[endpointName] = new ActionCreators(endpointName, this.API[endpointName], this.actionTypes[endpointName]);
       this.reducers[endpointName + '_items'] = new ItemReducer(this.actionTypes[endpointName]).getReducer();

--- a/test/Endpoint.spec.js
+++ b/test/Endpoint.spec.js
@@ -15,6 +15,17 @@ describe('Endpoint', () => {
       sinon.assert.calledWith(csrf, request);
     });
 
+    it('should be able to set headers from custom function', () => {
+      const custom = (request) => {
+        request.set('X-Custom', '1');
+        return request;
+      };
+      let endpoint = new Endpoint('', {setCSRF: custom});
+      let request = superagent.post('');
+      let expectation = sinon.mock(request).expects('set').once();
+      expectation.withArgs('X-Custom', '1');
+    });
+    
     it('should set headers when withCSRF is true', () => {
       let endpoint = new Endpoint('', {withCSRF: true});
       sinon.stub(endpoint, '_getCookie', () => 'cookie');

--- a/test/Endpoint.spec.js
+++ b/test/Endpoint.spec.js
@@ -18,7 +18,7 @@ describe('Endpoint', () => {
     it('should set headers when withCSRF is true', () => {
       let endpoint = new Endpoint('', {withCSRF: true});
       sinon.stub(endpoint, '_getCookie', () => 'cookie');
-      let request = superagent.post();
+      let request = superagent.post('');
       let expectation = sinon.mock(request).expects('set').once();
       expectation.withArgs('X-CSRFToken', 'cookie');
       endpoint._setCSRFHeader(request);
@@ -27,7 +27,7 @@ describe('Endpoint', () => {
 
     it('should not set headers when withCSRF is false', () => {
       let endpoint = new Endpoint('');
-      let request = superagent.post();
+      let request = superagent.post('');
       let expectation = sinon.mock(request).expects('set').never();
       endpoint._setCSRFHeader(request);
       expectation.verify();
@@ -36,7 +36,7 @@ describe('Endpoint', () => {
     it('should use custom CSRFHeaderName', () => {
       let endpoint = new Endpoint('', {withCSRF: true, CSRFHeaderName: 'X-Fred'});
       sinon.stub(endpoint, '_getCookie');
-      let request = superagent.post();
+      let request = superagent.post('');
       let expectation = sinon.mock(request).expects('set').once();
       expectation.withArgs('X-Fred');
       endpoint._setCSRFHeader(request);
@@ -46,7 +46,7 @@ describe('Endpoint', () => {
     it('should use custom CSRFCookieName', () => {
       let endpoint = new Endpoint('', {withCSRF: true, CSRFCookieName: 'testcookie'});
       let stub = sinon.stub(endpoint, '_getCookie');
-      let request = superagent.post();
+      let request = superagent.post('');
       sinon.stub(request, 'set');
       endpoint._setCSRFHeader(request);
       sinon.assert.calledWithExactly(stub, 'testcookie');


### PR DESCRIPTION
The code in master assumes a Django backend. Here we fix to allow complete customisation of how CSRF is handled so other backends can be used.