### PR TITLE
Remove all references to Flux

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,7 @@
+# History
+
+## 0.0.1-alpha.9
+
+- Rename main class from Flux to API
+- Remove all mentions of Flux
+- Require thunk middleware

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 **NOTE POST/PUT requests currently tied to Django Rest Framework's CSRF handling and response content**
 
-Automatically create Flux action constants, action creators and Redux
-reducers for your REST API.
+Create Redux action constants, action creators and reducers for your
+REST API with no boilerplate.
 
 ## Install
 ```
@@ -19,7 +19,9 @@ npm install redux-rest
 import React from 'react';
 import { connect, Provider } from 'react-redux';
 import { createStore, combineReducers, applyMiddleware } from 'redux';
-import Flux, { asyncDispatch } from 'redux-rest';
+import thunkMiddleware from 'redux-thunk';
+import API from 'redux-rest';
+
 
 // This is a super simple app that displays a list of users from an API and
 // lets you add new users. Until a success response is recevied from the API
@@ -32,17 +34,17 @@ const myAPI = {
   users: '/api/users/'
 };
 
-// Then create a Flux instance. This automatically creates
+// Then create an API instance. This automatically creates
 // action creators and reducers for each endpoint. No boilerplate!
-const flux = new Flux(myAPI);
+const api = new API(myAPI);
 
-// UserApp uses the flux object to fetch the users and create new ones
+// UserApp uses the api object to fetch the users and create new ones
 // using the automatically created action creators.
 class UserApp extends React.component {
 
   componentDidMount() {
     // Request the list of users when this component mounts
-    this.props.dispatch(flux.actionCreators.users.list());
+    this.props.dispatch(api.actionCreators.users.list());
   }
 
   render() {
@@ -65,7 +67,7 @@ class UserApp extends React.component {
     let inputNode = React.findDOMNode(this.refs.username);
     let val = inputNode.value;
     this.props.dispatch(
-      flux.actionCreators.users.create(
+      api.actionCreators.users.create(
         {username: val}
       )
     );
@@ -73,17 +75,14 @@ class UserApp extends React.component {
   }
 }
 
-// The flux object also has reducers to handle the standard REST actions
+// The api object also has reducers to handle the standard REST actions
 // So we can configure redux and connect our UserApp to it.
-let reducers = combineReducers(flux.reducers);
+let reducers = combineReducers(api.reducers);
 
-// To integrate with redux we need a middleware layer so we can do
-// async requests to the API server.
-// (Vanilla redux requires actions to be plain objects but the flux.actionCreators
-// methods return functions which launch an async request *then* dispatch the
-// corresponding action object).
+// To integrate with redux we require the thunk middleware to handle
+// action creators that return functions.
 let createStoreWithMiddleware = applyMiddleware(
-  asyncDispatch
+  thunkMiddleware
 )(createStore);
 
 let store = createStoreWithMiddleware(reducers);
@@ -112,22 +111,22 @@ export default class App extends React.Component {
 }
 ```
 
-## What is the Flux object?
+## What is the api object?
 
-The Flux object encapsulates common patterns when dealing with REST APIs.
+The api object encapsulates common patterns when dealing with REST APIs.
 
 When created with a description of your API you can call all the actions you'd
 expect and there are reducers that automatically handle those actions, including
 'pending', 'success' and 'failure' states.
 
 ```js
-import Flux from 'redux-rest';
+import API from 'redux-rest';
 
 const myAPI = {
     users: '/api/users/',
 }	   
 
-const flux = new Flux(myAPI);
+const api = new API(myAPI);
 ```
 
 This creates a pair of reducers for each API endpoint; a _collection_
@@ -139,7 +138,7 @@ reducer to handle actions on individual items.
 Calling actions is as simple as
 
 ```js 
-flux.actionCreators.users.create(userData);
+api.actionCreators.users.create(userData);
 ```
 
 ### Status of API requests
@@ -150,7 +149,7 @@ request the state change is marked as pending. For example, creating a
 new object,
 
 ```js
-flux.actionCreators.users.create({username: 'mark'});
+api.actionCreators.users.create({username: 'mark'});
 ```
 
 will add,

--- a/lib/reduxRest.js
+++ b/lib/reduxRest.js
@@ -384,8 +384,8 @@ var CollectionReducer = exports.CollectionReducer = function (_BaseReducer2) {
   return CollectionReducer;
 }(BaseReducer);
 
-var Flux = function Flux(APIConf, CSRFOptions) {
-  _classCallCheck(this, Flux);
+var API = function API(APIConf, CSRFOptions) {
+  _classCallCheck(this, API);
 
   this.API = {};
   this.actionTypes = {};
@@ -403,4 +403,4 @@ var Flux = function Flux(APIConf, CSRFOptions) {
   }
 };
 
-exports.default = Flux;
+exports.default = API;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-rest",
-  "version": "0.0.1-alpha.8",
+  "version": "0.0.1-alpha.9",
   "description": "Create Redux action constants, action creators and reducers for your REST API with no boilerplate.",
   "main": "lib/reduxRest.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "redux-rest",
   "version": "0.0.1-alpha.8",
-  "description": "Automatically create Flux action constants, action creators and Redux reducers for your REST API",
+  "description": "Create Redux action constants, action creators and reducers for your REST API with no boilerplate.",
   "main": "lib/reduxRest.js",
   "scripts": {
     "build": "scripts/build",
@@ -54,6 +54,7 @@
     "superagent": "^1.2.0"
   },
   "peerDependencies": {
-    "redux": ">=1.0.0-rc"
+    "redux": ">=1.0.0-rc",
+    "redux-thunk": ">=1.0.0"
   }
 }

--- a/src/reduxRest.js
+++ b/src/reduxRest.js
@@ -269,7 +269,7 @@ export class CollectionReducer extends BaseReducer {
   }
 }
 
-export default class Flux {
+export default class API {
   constructor(APIConf, CSRFOptions) {
     this.API = {};
     this.actionTypes = {};

--- a/test/ReduxIntegration.js
+++ b/test/ReduxIntegration.js
@@ -1,19 +1,20 @@
 import { createStore, combineReducers, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
 import expect from 'expect';
 import nock from 'nock';
 
-import Flux, { asyncDispatch } from '../src/reduxRest';
+import API from '../src/reduxRest';
 
-describe('Flux', () => {
+describe('API', () => {
   it('should integrate with redux', () => {
     const myAPI = {
       users: 'http://example.com/api/users/'
     };
-    const flux = new Flux(myAPI);
-    const reducers = combineReducers(flux.reducers);
+    const api = new API(myAPI);
+    const reducers = combineReducers(api.reducers);
 
     let createStoreWithMiddleware = applyMiddleware(
-      asyncDispatch
+      thunkMiddleware
     )(createStore);
     const store = createStoreWithMiddleware(reducers);
     let scope = nock('http://example.com')
@@ -23,7 +24,7 @@ describe('Flux', () => {
         }]);
     store.dispatch(
       d => {
-        flux.actionCreators.users.list()(d).end(() => {
+        api.actionCreators.users.list()(d).end(() => {
           expect(store.getState()).toBe([{username: 'mark'}]);
           scope.done();
         });


### PR DESCRIPTION
I started this package when redux was quite new and still ‘another’
Flux. I’ve changed the main class exported and the docs to remove all
references to Flux.
